### PR TITLE
Fix: Correct image path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="70%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="70%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   


### PR DESCRIPTION
The image `tece.JPG` was referenced as `tece.jpg` in `index.html`, causing it to not display. This commit corrects the path to use the uppercase `.JPG` extension, matching the actual filename in the `imgs` directory.