### PR TITLE
Fix: Correct image path typos in all HTML files

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="75%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="75%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   

--- a/events.html
+++ b/events.html
@@ -15,7 +15,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="75%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="75%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   

--- a/projects.html
+++ b/projects.html
@@ -21,7 +21,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="75%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="75%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   

--- a/publications.html
+++ b/publications.html
@@ -21,7 +21,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="75%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="75%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   

--- a/teaching.html
+++ b/teaching.html
@@ -21,7 +21,7 @@
 <section>
   <aside>
   
-  	<img align="right" src="./imgs/tece.jpg" width="75%" height=auto hspace="0/" vspace="0/" />
+	<img align="right" src="./imgs/tece.JPG" width="75%" height=auto hspace="0/" vspace="0/" />
 
   </aside>
   


### PR DESCRIPTION
I've updated multiple HTML files to correct the image path for 'tece.JPG'. The image was incorrectly referenced as 'tece.jpg' (lowercase extension) in contact.html, events.html, projects.html, publications.html, and teaching.html.

This commit changes all instances of './imgs/tece.jpg' to './imgs/tece.JPG' to ensure the image displays correctly across all relevant pages.